### PR TITLE
added div to db.all.blocks

### DIFF
--- a/hub.rng
+++ b/hub.rng
@@ -262,15 +262,12 @@
 
   <define name="db.all.blocks" combine="choice">
     <choice>
-      <ref name="db.nopara.blocks"/>
-      <ref name="db.para.blocks"/>
-      <ref name="db.extension.blocks"/>
       <ref name="hub.div"/>
     </choice>
   </define>
 
   <define name="hub.div">
-    <a:documentation>Allow div (example: html to hub conversion)</a:documentation>
+    <a:documentation>Allow div (example: html to hub conversion).</a:documentation>
     <element name="div">
       <zeroOrMore>
         <choice>


### PR DESCRIPTION
Element div for nested block elements (non-sections).

For now, only block level childrens are allowed; maybe we need to add possibility to nest div in inline elements, later (see html element del).
